### PR TITLE
Standardize HelmRelease specs

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -5,8 +5,7 @@ metadata:
   name: &app ollama
   namespace: ai
 spec:
-  interval: 15m
-  timeout: 15m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -5,8 +5,7 @@ kind: HelmRelease
 metadata:
   name: &app open-webui
 spec:
-  interval: 15m
-  timeout: 15m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/paperless-ai/app/helmrelease.yaml
@@ -5,8 +5,7 @@ metadata:
   name: &app paperless-ai
   namespace: ai
 spec:
-  interval: 15m
-  timeout: 15m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/database/postgres-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/database/postgres-operator/app/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app postgres-operator
   namespace: default
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: postgres-operator

--- a/kubernetes/apps/default/gitlab-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/default/gitlab-runner/app/helmrelease.yaml
@@ -21,6 +21,10 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
+  valuesFrom:
+    - kind: Secret
+      name: gitlab-k8s-runner-secrets
+      valuesKey: values.yaml
   values: # https://gitlab.com/gitlab-org/charts/gitlab-runner/blob/main/values.yaml
     imagePullPolicy: IfNotPresent
     gitlabUrl: https://gitlab.com/
@@ -35,7 +39,3 @@ spec:
             namespace = "default"
             privileged = true
 
-  valuesFrom:
-    - kind: Secret
-      name: gitlab-k8s-runner-secrets
-      valuesKey: values.yaml

--- a/kubernetes/apps/default/gitlab-runner2/app/helmrelease.yaml
+++ b/kubernetes/apps/default/gitlab-runner2/app/helmrelease.yaml
@@ -21,6 +21,10 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
+  valuesFrom:
+    - kind: Secret
+      name: gitlab-k8s-runner-secrets2
+      valuesKey: values.yaml
   values: # https://gitlab.com/gitlab-org/charts/gitlab-runner2/blob/main/values.yaml
     imagePullPolicy: IfNotPresent
     gitlabUrl: https://gitlab.com/
@@ -35,7 +39,3 @@ spec:
             namespace = "default"
             privileged = true
 
-  valuesFrom:
-    - kind: Secret
-      name: gitlab-k8s-runner-secrets2
-      valuesKey: values.yaml

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -20,7 +20,6 @@ spec:
   upgrade:
     cleanupOnFail: true
     remediation:
-      strategy: rollback
       retries: 3
   dependsOn:
     - name: flux-operator

--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -20,7 +20,6 @@ spec:
   upgrade:
     cleanupOnFail: true
     remediation:
-      strategy: rollback
       retries: 3
   valuesFrom:
     - kind: ConfigMap

--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -20,7 +20,6 @@ spec:
   upgrade:
     cleanupOnFail: true
     remediation:
-      strategy: rollback
       retries: 3
   valuesFrom:
     - kind: ConfigMap

--- a/kubernetes/apps/media/calibre-web/app/helmrelease.yaml
+++ b/kubernetes/apps/media/calibre-web/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app calibre-web
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/overseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/overseerr/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app overseerr
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/plex-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex-exporter/app/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
     name: app-template
   install:
     remediation:
-      retries: -1
+      retries: 3
   upgrade:
     cleanupOnFail: true
     remediation:

--- a/kubernetes/apps/media/plex-trakt-sync/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex-trakt-sync/app/helmrelease.yaml
@@ -5,7 +5,7 @@ metadata:
   name: &app plex-trakt-sync
   namespace: media
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -5,7 +5,7 @@ metadata:
   name: tautulli
   namespace: media
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/network/external/external-dns/helmrelease.yaml
+++ b/kubernetes/apps/network/external/external-dns/helmrelease.yaml
@@ -24,7 +24,6 @@ spec:
     cleanupOnFail: true
     crds: CreateReplace
     remediation:
-      strategy: rollback
       retries: 3
   values:
     fullnameOverride: *app

--- a/kubernetes/apps/network/internal/unifi-dns/helmrelease.yaml
+++ b/kubernetes/apps/network/internal/unifi-dns/helmrelease.yaml
@@ -24,7 +24,6 @@ spec:
     cleanupOnFail: true
     crds: CreateReplace
     remediation:
-      strategy: rollback
       retries: 3
   values:
     fullnameOverride: *app

--- a/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app blackbox-exporter
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: prometheus-blackbox-exporter

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: gatus
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/observability/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/grafana/app/helmrelease.yaml
@@ -6,8 +6,7 @@ metadata:
   name: grafana
   namespace: observability
 spec:
-  interval: 30m
-  timeout: 15m
+  interval: 1h
   chart:
     spec:
       chart: grafana
@@ -21,10 +20,9 @@ spec:
     remediation:
       retries: 3
   upgrade:
-    cleanupOnFail: true
     crds: Skip
+    cleanupOnFail: true
     remediation:
-      strategy: rollback
       retries: 3
   values:
     assertNoLeakedSecrets: false

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.dis
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.dis
@@ -5,8 +5,7 @@ metadata:
   name: kube-prometheus-stack
   namespace: observability
 spec:
-  interval: 30m
-  timeout: 15m
+  interval: 1h
   chart:
     spec:
       chart: kube-prometheus-stack
@@ -20,10 +19,9 @@ spec:
     remediation:
       retries: 3
   upgrade:
-    cleanupOnFail: true
     crds: Skip
+    cleanupOnFail: true
     remediation:
-      strategy: rollback
       retries: 3
   values:
     crds:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -4,8 +4,7 @@ metadata:
   name: kube-prometheus-stack
   namespace: observability
 spec:
-  interval: 30m
-  timeout: 15m
+  interval: 1h
   chart:
     spec:
       chart: kube-prometheus-stack
@@ -19,10 +18,9 @@ spec:
     remediation:
       retries: 3
   upgrade:
-    cleanupOnFail: true
     crds: Skip
+    cleanupOnFail: true
     remediation:
-      strategy: rollback
       retries: 3
   values:
     cleanPrometheusOperatorObjectNames: true

--- a/kubernetes/apps/observability/prowlarr-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prowlarr-exporter/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app prowlarr-exporter
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/observability/pushgateway/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/pushgateway/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app pushgateway
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: prometheus-pushgateway

--- a/kubernetes/apps/observability/radarr-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/radarr-exporter/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app radarr-exporter
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/observability/sabnzbd-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/sabnzbd-exporter/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app sabnzbd-exporter
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/observability/snmp-exporter/synology/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/synology/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: HelmRelease
 metadata:
   name: &app snmp-exporter-synology
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: prometheus-snmp-exporter

--- a/kubernetes/apps/observability/sonarr-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/sonarr-exporter/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app sonarr-exporter
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/observability/speedtest-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/speedtest-exporter/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app speedtest-exporter
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/observability/tautulli-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/tautulli-exporter/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app tautulli-exporter
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/productivity/code-server/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/code-server/app/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   name: code-server
   namespace: default
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/productivity/drop/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/drop/app/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app drop
   namespace: default
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/productivity/freshrss/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/freshrss/app/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app freshrss
   namespace: default
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/productivity/hajimari/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/hajimari/app/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app hajimari
   namespace: default
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: hajimari

--- a/kubernetes/apps/productivity/ladder/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/ladder/app/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app ladder
   namespace: default
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/productivity/linkding/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/linkding/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app linkding
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/productivity/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/n8n/app/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app n8n
   namespace: default
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/productivity/obsidian/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/obsidian/app/helmrelease.yaml
@@ -5,7 +5,7 @@ metadata:
   name: &app obsidian
   namespace: productivity
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/productivity/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/paperless/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: paperless
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/productivity/webtrees/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/webtrees/app/helmrelease.yaml
@@ -5,7 +5,7 @@ metadata:
   name: webtrees
   namespace: productivity
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template
@@ -14,10 +14,8 @@ spec:
         kind: HelmRepository
         name: bjw-s
         namespace: flux-system
-  maxHistory: 2
   install:
     crds: CreateReplace
-    createNamespace: true
     remediation:
       retries: 3
   upgrade:
@@ -25,8 +23,6 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
-  uninstall:
-    keepHistory: false
   dependsOn:
     - name: webtrees-db
   values:

--- a/kubernetes/apps/productivity/webtrees/db/helmrelease.yaml
+++ b/kubernetes/apps/productivity/webtrees/db/helmrelease.yaml
@@ -5,7 +5,7 @@ metadata:
   name: webtrees-db
   namespace: productivity
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: mariadb

--- a/kubernetes/apps/security/external-secrets/operator/helmrelease.yaml
+++ b/kubernetes/apps/security/external-secrets/operator/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: HelmRelease
 metadata:
   name: external-secrets
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: external-secrets

--- a/kubernetes/apps/security/external-secrets/secretstores/onepassword/helmrelease.yaml
+++ b/kubernetes/apps/security/external-secrets/secretstores/onepassword/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: HelmRelease
 metadata:
   name: onepassword-connect
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/security/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/security/kyverno/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app kyverno
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: kyverno

--- a/kubernetes/apps/security/trivy-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/security/trivy-operator/app/helmrelease.yaml
@@ -5,7 +5,7 @@ kind: HelmRelease
 metadata:
   name: aquasecurity
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: trivy-operator

--- a/kubernetes/apps/storage/k8up/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/k8up/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app k8up
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: k8up

--- a/kubernetes/apps/storage/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/longhorn/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app longhorn
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: longhorn

--- a/kubernetes/apps/storage/synology-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/synology-csi/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app synology-csi
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: synology-csi

--- a/kubernetes/apps/storage/velero/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/velero/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app velero
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: velero

--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml
@@ -20,7 +20,6 @@ spec:
   upgrade:
     cleanupOnFail: true
     remediation:
-      strategy: rollback
       retries: 3
   values:
     controllers:

--- a/kubernetes/apps/tools/headscale/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/headscale/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app headscale
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/tools/pod-cleaner/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/pod-cleaner/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app pod-cleaner
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/tools/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/smtp-relay/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app smtp-relay
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/tools/spoolman/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/spoolman/app/helmrelease.yaml
@@ -4,7 +4,7 @@ kind: HelmRelease
 metadata:
   name: &app spoolman
 spec:
-  interval: 30m
+  interval: 1h
   chart:
     spec:
       chart: app-template

--- a/kubernetes/apps/vpa/goldilocks/app/helmrelease.yaml
+++ b/kubernetes/apps/vpa/goldilocks/app/helmrelease.yaml
@@ -20,7 +20,6 @@ spec:
   upgrade:
     cleanupOnFail: true
     remediation:
-      strategy: rollback
       retries: 3
   values:
     vpa:


### PR DESCRIPTION
## Summary
- normalize HelmRelease specs to include only the standard fields
- restore fields like dependsOn, valuesFrom, disableSchemaValidation and crds where present

## Testing
- `grep -r "interval: 1h" kubernetes/apps | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68567ef6ef0c832c97003035dd34f759