### PR TITLE
fix: remove cilium operator toleration override

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -24,6 +24,3 @@ spec:
   valuesFrom:
     - kind: ConfigMap
       name: cilium-values
-  values:
-    operator:
-      tolerations: []


### PR DESCRIPTION
## Summary
- remove empty `operator.tolerations` override in cilium HelmRelease to avoid broken deployment

## Testing
- `helm template cilium /tmp/cilium/install/kubernetes/cilium -f kubernetes/apps/kube-system/cilium/app/helm/values.yaml --show-only templates/cilium-operator/deployment.yaml | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_689f0eb3d0b0832c8934a16e256e812c